### PR TITLE
Small bpaf improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
             // and ends when all worker threads drop their Senders.
             for (x, y, score) in rx.iter() {
                 scores.insert((x.clone(), y.clone()), score);
-                if score >= opts.sensitivity as f64 {
+                if score >= f64::from(opts.sensitivity) {
                     // keep this import scoped small, otherwise everything gets
                     // a billion color methods in rust-analyzer.
                     use owo_colors::OwoColorize;


### PR DESCRIPTION
- cli parser: handle glob expansion within the parser
- clippy: avoid potentially lossy casts

One of the main ideas for bpaf is the ability to perform extensive parsing and validation in the parser itself so if data reaches the main execution logic - it should be correct and ready to use. I think my patch might change the behavior a bit - it will complain and stop running rather than complain and resume but it should be possible to retain the original behavior too.

You can read a bit more about it here. It's in Haskell, but same ideas hold.
https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/

Feel free to drop either or both commits if you prefer your code to be the way it is now.